### PR TITLE
package.xml: tuned whitespaces

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -8,7 +8,7 @@
   </description>
   <author>Open Perception</author>
   <maintainer email="jkammerl@willowgarage.com">Julius Kammerl</maintainer>
-  <license>BSD</license>  
+  <license>BSD</license>
   <url>http://ros.org/wiki/pcl-msgs</url>
 
   <buildtool_depend>catkin</buildtool_depend>


### PR DESCRIPTION
This commit removes trailing whitespaces and makes the line with the license information in the package.xml bitwise match exactly the common license information line in most ROS packages.
The trailing whitespaces were detected when providing a bitbake recipe in the meta-ros project (github.com/bmwcarit/meta-ros). In the recipe, the hash of the license line is declared and is used to check for changes in the license. For this recipe, it was not matching the common one.
A related already merged commit is https://github.com/ros/std_msgs/pull/3.
