### PR TITLE
Add ClusterPointIndices for multiple clusters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ add_message_files(DIRECTORY msg
                         PointIndices.msg
                         PolygonMesh.msg
                         Vertices.msg
+                        ClusterPointIndices.msg
 )
 generate_messages(DEPENDENCIES sensor_msgs std_msgs)
 

--- a/msg/ClusterPointIndices.msg
+++ b/msg/ClusterPointIndices.msg
@@ -1,0 +1,2 @@
+Header header
+PointIndices[] cluster_indices 


### PR DESCRIPTION
Many segmentation algorithms output multiple clusters.
For example the region growing algorithm.

pcl_msgs should have a standard message for this. Based on jsk's implementation.

https://github.com/jsk-ros-pkg/jsk_recognition/blob/master/jsk_pcl_ros/msg/ClusterPointIndices.msg
