### PR TITLE
Updated messages to be explicit about the header struct

### DIFF
--- a/msg/ModelCoefficients.msg
+++ b/msg/ModelCoefficients.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 float32[] values
 

--- a/msg/PointIndices.msg
+++ b/msg/PointIndices.msg
@@ -1,3 +1,3 @@
-Header header
+std_msgs/Header header
 int32[] indices
 

--- a/msg/PolygonMesh.msg
+++ b/msg/PolygonMesh.msg
@@ -1,5 +1,5 @@
 # Separate header for the polygonal surface
-Header header
+std_msgs/Header header
 # Vertices of the mesh as a point cloud
 sensor_msgs/PointCloud2 cloud
 # List of polygons


### PR DESCRIPTION
This fixes certain edge case situations, where compilation errors occur such as

`In file included from bazel-out/k8-fastbuild/bin/external/ros2_pcl_msgs/pcl_msgs/msg/polygon_mesh__type_support.cpp:7:
bazel-out/k8-fastbuild/bin/external/ros2_pcl_msgs/pcl_msgs/msg/detail/polygon_mesh__struct.hpp:20:10: fatal error: 'pcl_msgs/msg/detail/header__struct.hpp' file not found
#include "pcl_msgs/msg/detail/header__struct.hpp"`